### PR TITLE
Fix catalog name to fix invalid relationship

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -3,14 +3,14 @@ class percona::repo::apt {
 
   apt::key { 'CD2EFD2A':
     ensure => present,
-    notify => Exec['apt-get update'],
+    notify => Exec['percona::repo::apt-get update'],
   }
 
   apt::sources_list { 'percona':
     ensure  => present,
     source  => false,
     content => template ("${module_name}/repo/sources.list.erb"),
-    notify  => Exec['apt-get update'],
+    notify  => Exec['percona::repo::apt-get update'],
   }
 
   exec { 'percona::repo::apt-get update':


### PR DESCRIPTION
...t-get update] }, because Exec[apt-get update] doesn't seem to be in the catalog
