### PR TITLE
Xtradb cluster

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -15,13 +15,14 @@
 class percona::cluster {
   if ( $percona::cluster ) {
     $params = {
-      'mysqld/server_id'             => $percona::cluster_index,
-      'mysqld/wsrep_cluster_address' => $percona::cluster_address,
-      'mysqld/wsrep_node_name'       => $percona::cluster_node_name,
-      'mysqld/wsrep_cluster_name'    => $percona::cluster_name,
-      'mysqld/wsrep_slave_threads'   => $percona::cluster_slave_threads,
-      'mysqld/wsrep_sst_method'      => $percona::cluster_sst_method,
-      'mysqld/wsrep_provider'        => $percona::cluster_wsrep_provider,
+      'mysqld/server_id'                => $percona::cluster_index,
+      'mysqld/wsrep_cluster_address'    => $percona::cluster_address,
+      'mysqld/wsrep_node_name'          => $percona::cluster_node_name,
+      'mysqld/wsrep_cluster_name'       => $percona::cluster_name,
+      'mysqld/wsrep_slave_threads'      => $percona::cluster_slave_threads,
+      'mysqld/wsrep_sst_method'         => $percona::cluster_sst_method,
+      'mysqld/wsrep_provider'           => $percona::cluster_wsrep_provider,
+      'mysqld/innodb_autoinc_lock_mode' => '2',
     }
   }
 }

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -12,21 +12,7 @@
 #
 # TODO: Document parameters
 #
-class percona::cluster (
-  $cluster           = false,
-  $cluster_index     = undef,
-  $cluster_address   = 'gcomm://',
-  $cluster_node_name = $fqdn,
-  $cluster_name      = undef,
-  $cluster_slave_threads = 2,
-  $cluster_sst_method = 'xtrabackup',
-) {
-
-  $cluster_wsrep_provider = $::hardwareisa ? {
-    'x86_64' => '/usr/lib64/libgalera_smm.so',
-    default  => '/usr/lib/libgalera_smm.so',
-  }
-
+class percona::cluster {
   if ( $percona::cluster ) {
     $params = {
       'mysqld/server_id'             => $percona::cluster_index,
@@ -35,7 +21,7 @@ class percona::cluster (
       'mysqld/wsrep_cluster_name'    => $percona::cluster_name,
       'mysqld/wsrep_slave_threads'   => $percona::cluster_slave_threads,
       'mysqld/wsrep_sst_method'      => $percona::cluster_sst_method,
-      'mysqld/wsrep_provider'        => $percona::cluster_wsrep_lib,
+      'mysqld/wsrep_provider'        => $percona::cluster_wsrep_provider,
     }
   }
 }

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -22,6 +22,7 @@ class percona::cluster {
       'mysqld/wsrep_slave_threads'      => $percona::cluster_slave_threads,
       'mysqld/wsrep_sst_method'         => $percona::cluster_sst_method,
       'mysqld/wsrep_provider'           => $percona::cluster_wsrep_provider,
+      'mysqld/wsrep_sst_auth'           => "${percona::cluster_replication_user}:${percona::cluster_replication_password}",
       'mysqld/innodb_autoinc_lock_mode' => '2',
     }
   }

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -26,4 +26,14 @@ class percona::cluster {
       'mysqld/innodb_autoinc_lock_mode' => '2',
     }
   }
+
+  # For checking the cluster's health
+  if $::percona::cluster {
+    file { '/etc/xinetd.d/mysqlchk':
+      source => "puppet:///modules/percona/xinetd.d/mysqlchk",
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0555',
+    }
+  }
 }

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -1,0 +1,41 @@
+# == Class percona::params
+#
+# === Parameters:
+#
+# === Provided parameters:
+#
+# === Examples:
+#
+# ==== Setting global and default configuration options.
+#
+# === Todo:
+#
+# TODO: Document parameters
+#
+class percona::cluster (
+  $cluster           = false,
+  $cluster_index     = undef,
+  $cluster_address   = 'gcomm://',
+  $cluster_node_name = $fqdn,
+  $cluster_name      = undef,
+  $cluster_slave_threads = 2,
+  $cluster_sst_method = 'xtrabackup',
+) {
+
+  $cluster_wsrep_provider = $::hardwareisa ? {
+    'x86_64' => '/usr/lib64/libgalera_smm.so',
+    default  => '/usr/lib/libgalera_smm.so',
+  }
+
+  if ( $percona::cluster ) {
+    $params = {
+      'mysqld/server_id'             => $percona::cluster_index,
+      'mysqld/wsrep_cluster_address' => $percona::cluster_address,
+      'mysqld/wsrep_node_name'       => $percona::cluster_node_name,
+      'mysqld/wsrep_cluster_name'    => $percona::cluster_name,
+      'mysqld/wsrep_slave_threads'   => $percona::cluster_slave_threads,
+      'mysqld/wsrep_sst_method'      => $percona::cluster_sst_method,
+      'mysqld/wsrep_provider'        => $percona::cluster_wsrep_lib,
+    }
+  }
+}

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -83,6 +83,13 @@ class percona::config::server {
     $params_version = {}
   }
 
+  # Cluster specifics.
+  if $params['cluster'] {
+    $params_cluster = $params['cluster']
+  } else {
+    $params_version = {}
+  }
+
   # Special case. Only add this parameter if it has been set. We need to do
   # this like this because we can not adjust the params hash after it has been
   # defined.
@@ -99,6 +106,7 @@ class percona::config::server {
     $default_global,
     $params_version,
     $params_global,
+    $params_cluster,
     $tempdir,
   ]
 

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -87,7 +87,7 @@ class percona::config::server {
   if $params['cluster'] {
     $params_cluster = $params['cluster']
   } else {
-    $params_version = {}
+    $params_cluster = {}
   }
 
   # Special case. Only add this parameter if it has been set. We need to do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,8 @@ class percona (
   $cluster_address   = $percona::params::cluster_address,
   $cluster_node_name = $percona::params::cluster_node_name,
   $cluster_name      = $percona::params::cluster_name,
+  $cluster_replication_user = $percona::params::cluster_replication_user,
+  $cluster_replication_password = $percona::params::cluster_replication_password,
   $cluster_slave_threads = $percona::params::cluster_slave_threads,
   $cluster_sst_method = $percona::params::cluster_sst_method,
   $cluster_wsrep_provider = $percona::params::cluster_wsrep_provider,
@@ -127,6 +129,9 @@ class percona (
     }
     if ( !$cluster_index or !cluster_name or !$cluster_node_name ) {
       fail("Percona cluster needs cluster_index (my.cnf:server_id), cluster_name (my.cnf:wsrep_cluster_name), and cluster_node_name (my.cnf:wsrep_node_name)!")
+    }
+    if ( !$cluster_replication_user or !$cluster_replication_password ) {
+      fail("Percona cluster needs cluster_replication_user and cluster_replication_password (my.cnf:wsrep_sst_auth=user:password)!")
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,9 +71,14 @@ class percona (
   $config_replace   = $percona::params::config_replace,
   $config_include_dir = $::percona::params::config_include_dir,
   $server           = $percona::params::server,
-  $cluster          = $percona::params::cluster,
-  $cluster_index    = $percona::params::cluster_index,
-  $cluster_wsrep_lib = $percona::params::cluster_wsrep_lib,
+  $cluster          = $percona::cluster::cluster,
+  $cluster_index    = $percona::cluster::cluster_index,
+  $cluster_address   = $percona::cluster::cluster_address,
+  $cluster_node_name = $percona::cluster::cluster_node_name,
+  $cluster_name      = $percona::cluster::cluster_name,
+  $cluster_slave_threads = $percona::cluster::cluster_slave_threads,
+  $cluster_sst_method = $percona::cluster::cluster_sst_method,
+  $cluster_wsrep_lib = $percona::cluster::cluster_wsrep_lib,
   $service_enable   = $percona::params::service_enable,
   $service_ensure   = $percona::params::service_ensure,
   $service_name     = $percona::params::service_name,
@@ -110,15 +115,21 @@ class percona (
 
 ) inherits percona::params {
 
+  include percona::cluster
+
   $config_includedir = $config_include_dir ? {
     undef   => $config_include_dir_default,
     default => $config_include_dir,
   }
 
-  if ( $cluster and !$server ) {
-    fail("Percona cluster without server!")
+  if ( $cluster ) {
+    if ( !$server ) {
+      fail("Percona cluster without server!")
+    }
+    if ( !$cluster_index or !cluster_name or !$cluster_node_name ) {
+      fail("Percona cluster needs cluster_index (my.cnf:server_id), cluster_name (my.cnf:wsrep_cluster_name), and cluster_node_name (my.cnf:wsrep_node_name)!")
+    }
   }
-
 
   ## Translate settings in params in a hash.
   $params = {
@@ -140,6 +151,7 @@ class percona (
       'xtrabackup/datadir'               => $::percona::datadir,
       'xtrabackup/target_dir'            => $::percona::targetdir,
     },
+    'cluster'                            => $::percona::cluster::params,
   }
 
   include percona::preinstall
@@ -147,6 +159,8 @@ class percona (
   include percona::config
   include percona::service
 
+  Class['percona::cluster'] ->
+  Class['percona'] ->
   Class['percona::preinstall'] ->
   Class['percona::install'] ->
   Class['percona::config'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ class percona (
   $config_replace   = $percona::params::config_replace,
   $config_include_dir = $::percona::params::config_include_dir,
   $server           = $percona::params::server,
+  $cluster          = $percona::params::cluster,
   $service_enable   = $percona::params::service_enable,
   $service_ensure   = $percona::params::service_ensure,
   $service_name     = $percona::params::service_name,
@@ -107,6 +108,10 @@ class percona (
   $config_includedir = $config_include_dir ? {
     undef   => $config_include_dir_default,
     default => $config_include_dir,
+  }
+
+  if ( $cluster and !$server ) {
+    fail("Percona cluster without server!")
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,8 @@ class percona (
   $config_include_dir = $::percona::params::config_include_dir,
   $server           = $percona::params::server,
   $cluster          = $percona::params::cluster,
+  $cluster_index    = $percona::params::cluster_index,
+  $cluster_wsrep_lib = $percona::params::cluster_wsrep_lib,
   $service_enable   = $percona::params::service_enable,
   $service_ensure   = $percona::params::service_ensure,
   $service_name     = $percona::params::service_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,14 +71,14 @@ class percona (
   $config_replace   = $percona::params::config_replace,
   $config_include_dir = $::percona::params::config_include_dir,
   $server           = $percona::params::server,
-  $cluster          = $percona::cluster::cluster,
-  $cluster_index    = $percona::cluster::cluster_index,
-  $cluster_address   = $percona::cluster::cluster_address,
-  $cluster_node_name = $percona::cluster::cluster_node_name,
-  $cluster_name      = $percona::cluster::cluster_name,
-  $cluster_slave_threads = $percona::cluster::cluster_slave_threads,
-  $cluster_sst_method = $percona::cluster::cluster_sst_method,
-  $cluster_wsrep_lib = $percona::cluster::cluster_wsrep_lib,
+  $cluster          = $percona::params::cluster,
+  $cluster_index    = $percona::params::cluster_index,
+  $cluster_address   = $percona::params::cluster_address,
+  $cluster_node_name = $percona::params::cluster_node_name,
+  $cluster_name      = $percona::params::cluster_name,
+  $cluster_slave_threads = $percona::params::cluster_slave_threads,
+  $cluster_sst_method = $percona::params::cluster_sst_method,
+  $cluster_wsrep_provider = $percona::params::cluster_wsrep_provider,
   $service_enable   = $percona::params::service_enable,
   $service_ensure   = $percona::params::service_ensure,
   $service_name     = $percona::params::service_name,
@@ -114,7 +114,6 @@ class percona (
   $config_file      = $percona::params::config_file,
 
 ) inherits percona::params {
-
   include percona::cluster
 
   $config_includedir = $config_include_dir ? {
@@ -160,7 +159,6 @@ class percona (
   include percona::service
 
   Class['percona::cluster'] ->
-  Class['percona'] ->
   Class['percona::preinstall'] ->
   Class['percona::install'] ->
   Class['percona::config'] ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,40 +4,37 @@
 class percona::install {
   $server           = $::percona::server
   $client           = $::percona::client
+  $cluster          = $::percona::cluster
   $percona_version  = $::percona::percona_version
 
   case $::operatingsystem {
     /(?i:debian|ubuntu)/: {
       $pkg_version = $percona_version
-      $pkg_client_default = "percona-server-client-${pkg_version}"
-      $pkg_server_default = "percona-server-server-${pkg_version}"
-
-      case $percona_version {
-        '5.1': {
-          $pkg_common_default = [
-            'percona-toolkit',
-            "percona-server-common"
-          ]
-        }
-
-        default: {
-          $pkg_common_default = [
-            'percona-toolkit',
-            "percona-server-common-${pkg_version}"
-          ]
-        }
+      if $cluster {
+        $pkg_client_default = "percona-xtradb-cluster-client-${pkg_version}"
+        $pkg_server_default = "percona-xtradb-cluster-server-${pkg_version}"
       }
+      else {
+        $pkg_client_default = "percona-server-client-${pkg_version}"
+        $pkg_server_default = "percona-server-server-${pkg_version}"
+      }
+
+      $pkg_common_default = [ 'percona-toolkit' ]
     }
 
     /(?i:redhat|centos)/: {
       $pkg_version = regsubst($percona_version, '\.', '', 'G')
 
-      $pkg_client_default = "Percona-Server-client-${pkg_version}"
-      $pkg_server_default = "Percona-Server-server-${pkg_version}"
-      $pkg_common_default = [
-        "Percona-Server-shared-${pkg_version}",
-        'percona-toolkit'
-      ]
+      if $cluster {
+        $pkg_client_default = "Percona-XtraDB-Cluster-client"
+        $pkg_server_default = "Percona-XtraDB-Cluster-server"
+      }
+      else {
+        $pkg_client_default = "Percona-Server-client-${pkg_version}"
+        $pkg_server_default = "Percona-Server-server-${pkg_version}"
+      }
+
+      $pkg_common_default = [ 'percona-toolkit' ]
 
       # Installation of Percona's shared compatibility libraries
       case $percona_version {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,21 +23,13 @@ class percona::install {
         $pkg_server_default = "percona-server-server-${pkg_version}"
 
 	# Avoid dependency resolution on version change
-        case $percona_version {
-          '5.1': {
-            $pkg_common_default = [
-              'percona-toolkit',
-              "percona-server-common"
-            ]
-          }
-
-          default: {
-            $pkg_common_default = [
-              'percona-toolkit',
-              "percona-server-common-${pkg_version}"
-            ]
-          }
-        }
+        $pkg_common_default = [
+          'percona-toolkit',
+          $percona_version ? {
+            '5.1'   => 'percona-server-common',
+            default => "percona-server-common-${pkg_version}",
+          },
+        ]
       }
     }
 
@@ -65,7 +57,7 @@ class percona::install {
         $pkg_server_default = "Percona-Server-server-${pkg_version}"
         $pkg_common_default = [
           "Percona-Server-shared-${pkg_version}",
-          'percona-toolkit'
+          'percona-toolkit',
         ]
       }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,18 +39,11 @@ class percona::install {
       if $cluster {
         $pkg_client_default = "Percona-XtraDB-Cluster-client"
         $pkg_server_default = "Percona-XtraDB-Cluster-server"
-	# XXX:  Doesn't actually work because undef and false evaulate the same
-	if ( $pkg_compat != undef ) {
-          $pkg_common_default = [
-            'percona-toolkit',
-            'Percona-XtraDB-Cluster-shared',
-          ]
-        }
-        else {
-          $pkg_common_default = [
-            'percona-toolkit',
-          ]
-        }
+	# The Percona-Compat packages break clusteing.
+        $pkg_common_default = [
+          'percona-toolkit',
+          'Percona-XtraDB-Cluster-shared',
+        ]
       }
       else {
         $pkg_client_default = "Percona-Server-client-${pkg_version}"
@@ -62,17 +55,19 @@ class percona::install {
       }
 
       # Installation of Percona's shared compatibility libraries
-      case $percona_version {
-        '5.5': {
-          $pkg_compat = $::percona::pkg_compat ? {
-            undef   => 'Percona-Server-shared-compat',
-            default => $::percona::pkg_compat,
+      if ( ! $cluster ) {
+        case $percona_version {
+          '5.5': {
+            $pkg_compat = $::percona::pkg_compat ? {
+              undef   => 'Percona-Server-shared-compat',
+              default => $::percona::pkg_compat,
+            }
           }
-        }
-        default: {
-          $pkg_compat = $::percona::pkg_compat ? {
-            undef   => 'Percona-SQL-shared-compat',
-            default => $::percona::pkg_compat,
+          default: {
+            $pkg_compat = $::percona::pkg_compat ? {
+              undef   => 'Percona-SQL-shared-compat',
+              default => $::percona::pkg_compat,
+            }
           }
         }
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,13 +13,32 @@ class percona::install {
       if $cluster {
         $pkg_client_default = "percona-xtradb-cluster-client-${pkg_version}"
         $pkg_server_default = "percona-xtradb-cluster-server-${pkg_version}"
+        $pkg_common_default = [
+          'percona-toolkit',
+          "percona-xtradb-cluster-common-${pkg_version}",
+        ]
       }
       else {
         $pkg_client_default = "percona-server-client-${pkg_version}"
         $pkg_server_default = "percona-server-server-${pkg_version}"
-      }
 
-      $pkg_common_default = [ 'percona-toolkit' ]
+	# Avoid dependency resolution on version change
+        case $percona_version {
+          '5.1': {
+            $pkg_common_default = [
+              'percona-toolkit',
+              "percona-server-common"
+            ]
+          }
+
+          default: {
+            $pkg_common_default = [
+              'percona-toolkit',
+              "percona-server-common-${pkg_version}"
+            ]
+          }
+        }
+      }
     }
 
     /(?i:redhat|centos)/: {
@@ -28,13 +47,27 @@ class percona::install {
       if $cluster {
         $pkg_client_default = "Percona-XtraDB-Cluster-client"
         $pkg_server_default = "Percona-XtraDB-Cluster-server"
+	# XXX:  Doesn't actually work because undef and false evaulate the same
+	if ( $pkg_compat != undef ) {
+          $pkg_common_default = [
+            'percona-toolkit',
+            'Percona-XtraDB-Cluster-shared',
+          ]
+        }
+        else {
+          $pkg_common_default = [
+            'percona-toolkit',
+          ]
+        }
       }
       else {
         $pkg_client_default = "Percona-Server-client-${pkg_version}"
         $pkg_server_default = "Percona-Server-server-${pkg_version}"
+        $pkg_common_default = [
+          "Percona-Server-shared-${pkg_version}",
+          'percona-toolkit'
+        ]
       }
-
-      $pkg_common_default = [ 'percona-toolkit' ]
 
       # Installation of Percona's shared compatibility libraries
       case $percona_version {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,11 +39,16 @@ class percona::install {
       if $cluster {
         $pkg_client_default = "Percona-XtraDB-Cluster-client"
         $pkg_server_default = "Percona-XtraDB-Cluster-server"
-	# The Percona-Compat packages break clusteing.
-        $pkg_common_default = [
-          'percona-toolkit',
-          'Percona-XtraDB-Cluster-shared',
-        ]
+	# The Percona-Compat packages break Cluster-shared.
+        if ( $::percona::pkg_compat == false ) {
+          $pkg_common_default = [
+            'percona-toolkit',
+            'Percona-XtraDB-Cluster-shared',
+          ]
+        }
+        else {
+          $pkg_common_default = 'percona-toolkit' 
+        }
       }
       else {
         $pkg_client_default = "Percona-Server-client-${pkg_version}"
@@ -55,19 +60,18 @@ class percona::install {
       }
 
       # Installation of Percona's shared compatibility libraries
-      if ( ! $cluster ) {
-        case $percona_version {
-          '5.5': {
-            $pkg_compat = $::percona::pkg_compat ? {
-              undef   => 'Percona-Server-shared-compat',
-              default => $::percona::pkg_compat,
-            }
+      case $percona_version {
+        '5.5': {
+          $pkg_compat = $::percona::pkg_compat ? {
+            undef    => 'Percona-Server-shared-compat',
+            false    => '',
+            default  => $::percona::pkg_compat,
           }
-          default: {
-            $pkg_compat = $::percona::pkg_compat ? {
-              undef   => 'Percona-SQL-shared-compat',
-              default => $::percona::pkg_compat,
-            }
+        }
+        default: {
+          $pkg_compat = $::percona::pkg_compat ? {
+            undef   => 'Percona-SQL-shared-compat',
+            default => $::percona::pkg_compat,
           }
         }
       }
@@ -77,6 +81,7 @@ class percona::install {
       fail('Operating system not supported yet.')
     }
   }
+#        fail("package is $pkg_compat")
 
   $pkg_client = $::percona::pkg_client ? {
     undef   => $pkg_client_default,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@
 # TODO: Document parameters
 #
 class percona::params (
-  $percona_version   = '5.1',
+  $percona_version   = '5.5',
   $client            = true,
   $config_content    = undef,
   $config_dir_mode   = '0750',
@@ -53,6 +53,7 @@ class percona::params (
   $config_replace    = true,
   $config_include_dir = undef,
   $server            = false,
+  $cluster           = false,
   $service_enable    = true,
   $service_ensure    = 'running',
   $service_name      = 'mysql',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,7 @@ class percona::params (
   $config_include_dir = undef,
   $server            = false,
   $cluster           = false,
+  $cluster_index     = undef,
   $service_enable    = true,
   $service_ensure    = 'running',
   $service_name      = 'mysql',
@@ -107,5 +108,10 @@ class percona::params (
     default: {
       fail('Operating system not supported yet.')
     }
+  }
+
+  $cluster_wsrep_lib = $::hardwareisa ? {
+    'x86_64' => '/usr/lib64/libgalera_smm.so',
+    default  => '/usr/lib/libgalera_smm.so',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,8 +53,6 @@ class percona::params (
   $config_replace    = true,
   $config_include_dir = undef,
   $server            = false,
-  $cluster           = false,
-  $cluster_index     = undef,
   $service_enable    = true,
   $service_ensure    = 'running',
   $service_name      = 'mysql',
@@ -108,10 +106,5 @@ class percona::params (
     default: {
       fail('Operating system not supported yet.')
     }
-  }
-
-  $cluster_wsrep_lib = $::hardwareisa ? {
-    'x86_64' => '/usr/lib64/libgalera_smm.so',
-    default  => '/usr/lib/libgalera_smm.so',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,8 @@ class percona::params (
   $cluster_address   = 'gcomm://',
   $cluster_node_name = $fqdn,
   $cluster_name      = undef,
+  $cluster_replication_user = undef,
+  $cluster_replication_password = undef,
   $cluster_slave_threads = 2,
   $cluster_sst_method = 'xtrabackup',
   $daemon_group      = 'mysql',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,13 @@ class percona::params (
   $service_ensure    = 'running',
   $service_name      = 'mysql',
   $service_restart   = true,
+  $cluster           = false,
+  $cluster_index     = undef,
+  $cluster_address   = 'gcomm://',
+  $cluster_node_name = $fqdn,
+  $cluster_name      = undef,
+  $cluster_slave_threads = 2,
+  $cluster_sst_method = 'xtrabackup',
   $daemon_group      = 'mysql',
   $daemon_user       = 'mysql',
   $tmpdir            = undef,
@@ -106,5 +113,10 @@ class percona::params (
     default: {
       fail('Operating system not supported yet.')
     }
+  }
+
+  $cluster_wsrep_provider = $::hardwareisa ? {
+    'x86_64' => '/usr/lib64/libgalera_smm.so',
+    default  => '/usr/lib/libgalera_smm.so',
   }
 }


### PR DESCRIPTION
Was a bit over-zealous before.  First time working on an open source project, sent a pull request before it was ready.

I was going to request a pull to development, but your development branch looks like it needs a sync to your master branch badly.

This works well now.  Sample configuration below.

``` puppet
node /^db-\d+\.example\.com$/ {
  $svr_idx = regsubst($fqdn, '^db-(\d+)\.example\.com', '\1')

  # Install the cluster database server
  # Just YAML this and use hiera
  class { 'percona':
    server => 'true',
    cluster => 'true',
    cluster_index => $svr_idx,
    cluster_name => 'db-cluster',
    cluster_node_name => $hostname,
    cluster_address => $svr_idx ? {
      1 => 'gcomm://',
      default => 'gcomm://db-1.example.com',
    },
    cluster_replication_user => 'cluster',
    cluster_replication_password => 'cluster_password',
    targetdir => '/var/lib/mysql/backup',
# Set as below to install Percona-XtraDB-Cluster-common
# Otherwise leave undef, or you can't install redhat-lsb
#    pkg_compat => false,
    manage_repo  => 'true',
# Required.  If /etc/my.cnf is root:root, xtrabackup fails
# as it tries to reread the file as user mysql
    config_user  => 'mysql',
    config_group  => 'mysql',
# Do this if /var/lib/mysql is a mount point
    datadir => '/var/lib/mysql/db/',
    configuration => {
# Query cache is currently disabled with wsrep
#      'mysqld/query_cache_size' => '16M',
#      'mysqld/query_cache_limit' => '8M',
#      'mysqld/query_cache_type' => '1',
      'mysqld/max_connections' => '536',
      'mysqld/interactive_timeout' => '300',
      'mysqld/wait_timeout' => '300',
      'mysqld/connect_timeout' => '10',
      'mysqld/thread_cache_size' => '512',
      'mysqld/expire_logs_days' => '30',
      'mysqld/max_binlog_size' => '256M',
      'mysqld/table_cache' => '1024',
#      'mysqld/table_open_cache' => '512',
      'mysqld/table_definition_cache' => '1024',
      'mysqld/auto_increment_offset' => $svr_idx,
# Should be at least 2x the number of cores,
# or 1/4 the number of writing client connections
# the other nodes have
# Set to 1 if you have ANY tables without primary keys!
# Tables without primary keys make MySQL slow, so fix that...
      'mysqld/wsrep_slave_threads' => '1',
# This attempts to retry the commit 4 times if there's a deadlock
      'mysqld/wsrep_retry_autocommit' => '4',
    },
  }

  file { '/var/lib/mysql/backup':
    ensure => directory,
    mode => 'ug+rwX,o=r,o-x',
    owner => 'mysql',
    group => 'mysql',
  }
}
```
