### PR TITLE
Puppet-lint 0.3.2 qualified code

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,2 @@
 --no-80chars-check
+--no-class_inherits_from_params_class-check

--- a/manifests/adminpass.pp
+++ b/manifests/adminpass.pp
@@ -48,7 +48,7 @@ define percona::adminpass (
 ) {
 
   exec {"percona-adminpass-${name}":
-    onlyif => [
+    onlyif    => [
       'test -f /usr/bin/mysqladmin',
       "mysqladmin -u${user} -h${host} status",
     ],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,8 +9,8 @@ class percona::service {
 
   if $::percona::server {
     service { $service_name:
-      alias   => 'mysql',
       ensure  => $service_ensure,
+      alias   => 'mysql',
       enable  => $service_enable,
       require => [
         Class['percona::config::server'],


### PR DESCRIPTION
I did some minor changes to get the module qualifying the puppet-lint checks. 
Also added the '--no-class_inherits_from_params_class-check' to the .puppet-lint.rc file. 
