### PR TITLE
Bug fix

### DIFF
--- a/manifests/adminpass.pp
+++ b/manifests/adminpass.pp
@@ -50,7 +50,7 @@ define percona::adminpass (
   exec {"percona-adminpass-${name}":
     onlyif    => [
       'test -f /usr/bin/mysqladmin',
-      "mysqladmin -u${user} -h${host} --no-defaults status",
+      "mysqladmin --no-defaults -u${user} -h${host}  status",
     ],
     path      => ['/usr/bin','/bin',],
     command   => "mysqladmin -h ${host} -u${user} password ${password}",


### PR DESCRIPTION
Debug: Exec[ percona-adminpass-root ](provider=posix): Executing check 'mysqladmin -uroot -hlocalhost --no-defaults status'
Debug: Executing 'mysqladmin -uroot -hlocalhost --no-defaults status'
Debug: /Stage[main]//Node/Add_privileges onlyif: mysqladmin: unknown option '--no-defaults'
